### PR TITLE
fixed NittroExtension  to by compatible with Nette 3

### DIFF
--- a/src/Bridges/NittroDI/NittroExtension.php
+++ b/src/Bridges/NittroDI/NittroExtension.php
@@ -29,6 +29,7 @@ class NittroExtension extends CompilerExtension {
 
         if ($latte = $builder->getByType(ILatteFactory::class)) {
             $builder->getDefinition($latte)
+				->getResultDefinition()
                 ->addSetup('addProvider', [ 'nittro', new Statement(NittroRuntime::class) ])
                 ->addSetup(
                     '?->onCompile[] = function ($engine) { ' . NittroMacros::class . '::install($engine->getCompiler(), ?); }', [


### PR DESCRIPTION
fixed: Service latte.latteFactory: Nette\DI\Definitions\FactoryDefinition::addSetup() is deprecated, use ->getResultDefinition()->addSetup()