### PR TITLE
Fixed "Cannot use stdClass as array"

### DIFF
--- a/src/Bridges/NittroDI/NittroExtension.php
+++ b/src/Bridges/NittroDI/NittroExtension.php
@@ -38,7 +38,7 @@ class NittroExtension extends CompilerExtension {
                 ->addSetup(
                     '?->onCompile[] = function ($engine) { ' . NittroMacros::class . '::install($engine->getCompiler(), ?); }', [
                     '@self',
-                    $config['noconflict'],
+                    $config->noconflict,
                 ]);
         }
     }


### PR DESCRIPTION
Probably because of using nette/schema