### PR TITLE
issue declaration afterRender()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "nette/application": "^3.1.5",
+        "nette/application": "^3.2.0",
         "nette/di": "^3.0",
         "latte/latte": "^2.10"
     },

--- a/src/Bridges/NittroUI/Presenter.php
+++ b/src/Bridges/NittroUI/Presenter.php
@@ -19,7 +19,7 @@ abstract class Presenter extends UI\Presenter {
     }
 
 
-    protected function afterRender()
+    protected function afterRender(): void
     {
         parent::afterRender();
 


### PR DESCRIPTION
issue Declaration of Nittro\Bridges\NittroUI\Presenter::afterRender() must be compatible with Nette\Application\UI\Presenter::afterRender(): void since v3.2.0