### PR TITLE
nullable typehints fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         "classmap": ["src/"]
     },
     "require": {
-        "php": ">=7.2"
+        "php": ">=8.1"
     },
     "require-dev": {
-        "nette/application": "^3.2.0",
-        "nette/di": "^3.0",
+        "nette/application": "^3.2",
+        "nette/di": "^3.2",
         "latte/latte": "^2.10"
     },
     "minimum-stability": "RC",

--- a/src/Bridges/NittroUI/PresenterUtils.php
+++ b/src/Bridges/NittroUI/PresenterUtils.php
@@ -25,7 +25,7 @@ trait PresenterUtils {
 
     abstract public function isAjax() : bool;
 
-    abstract public function isControlInvalid(string $snippet = NULL) : bool;
+    abstract public function isControlInvalid(?string $snippet = NULL) : bool;
 
     /**
      * @param string $snippet


### PR DESCRIPTION
Deprecated: Nittro\Bridges\NittroUI\PresenterUtils::isControlInvalid(): Implicitly marking parameter $snippet as nullable is deprecated, the explicit nullable type must be used instead

nette/application 3.2 requires php 8.1 and nette/di 3.2